### PR TITLE
Keep track of music progress and play next song on completion

### DIFF
--- a/Pluto/pluto.js
+++ b/Pluto/pluto.js
@@ -31,6 +31,16 @@ module.exports = function(config, tests) {
     pluto.storage = {};
     pluto.listeners = {};
 
+    var makeId = function(length) {
+        var text = "";
+        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+        for( var i=0; i < length; i++ )
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+        return text;
+    };
+
     var hbs = exphbs.create({
         helpers: {
             button: function(verb, url, text, classes) {
@@ -56,6 +66,26 @@ module.exports = function(config, tests) {
                         '</form>'
                     );
                 }
+            },
+            ajax_button: function(verb, url, text, classes) {
+                verb = verb.toUpperCase();
+                text = handlebars.escapeExpression(text);
+                text = text || url;
+                console.log(classes);
+                classes = classes || "";
+                id = makeId(15);
+                if (classes) {
+                    classes = " " + classes;
+                }
+
+                return new handlebars.SafeString(
+                    '<a class="button' + classes + '" id="' + id + '">' + text + '</a>' +
+                    '<script type="text/javascript">' +
+                        'document.getElementById("' + id + '").addEventListener("click", function() { ' +
+                            'ajax("' + verb + '", "' + url + '"); ' +
+                        ' });' +
+                    '</script>'
+                );
             },
             button_disabled: function(text, classes) {
                 classes = classes || "";
@@ -114,16 +144,6 @@ module.exports = function(config, tests) {
                 return id;
             }
         }
-    };
-
-    var makeId = function(length) {
-        var text = "";
-        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-        for( var i=0; i < length; i++ )
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-
-        return text;
     };
 
     pluto.request = function(url, callback) {

--- a/plugins/music.js
+++ b/plugins/music.js
@@ -2,6 +2,7 @@ module.exports = function(pluto) {
 
     var data = pluto.getStorage("users")||{};
     var title = "Music Player";
+    var scripts = ["/javascripts/music_frontend.js"];
 
     var musicModule = {
         lastPlaying: null,
@@ -15,11 +16,15 @@ module.exports = function(pluto) {
         musicModule.progress = data;
     });
     pluto.get("/music/progress", function(req, res) {
-        res.render("music_playing.html", {
-            nowPlaying: musicModule.lastPlaying,
-            progress: musicModule.progress,
-            layout: false
-        });
+        if (musicModule.lastPlaying) {
+            res.json({
+                total: musicModule.progress.total,
+                current: musicModule.progress.current,
+                playing: !musicModule.paused
+            });
+        } else {
+            res.json({});
+        }
     });
 
     pluto.post("/music/add", function(req, response) {
@@ -259,7 +264,8 @@ module.exports = function(pluto) {
             queue: musicModule.queue,
             canSkip: musicModule.queue.length > 0 && musicModule.lastPlaying,
             canPlay: musicModule.paused || (!musicModule.lastPlaying && musicModule.queue.length > 0),
-            canPause: musicModule.lastPlaying && !musicModule.paused
+            canPause: musicModule.lastPlaying && !musicModule.paused,
+            scripts: scripts
         });
         musicModule.lastMessage = undefined;
     });

--- a/plugins/music.js
+++ b/plugins/music.js
@@ -16,7 +16,7 @@ module.exports = function(pluto) {
         musicModule.progress = data;
     });
     pluto.get("/music/progress", function(req, res) {
-        if (musicModule.lastPlaying) {
+        if (musicModule.lastPlaying && musicModule.progress) {
             res.json({
                 total: musicModule.progress.total,
                 current: musicModule.progress.current,

--- a/plugins/music.js
+++ b/plugins/music.js
@@ -194,7 +194,7 @@ module.exports = function(pluto) {
             musicModule.lastPlaying = musicModule.queue.shift();
             pluto.emitEvent("music::play", musicModule.lastPlaying, musicModule.queue[0]);
         } else {
-            musicModule.lastMessage = "Nothing in the musicModule.queue to play!";
+            musicModule.lastMessage = "Nothing in the queue to play!";
         }
         res.redirect("/music");
     });

--- a/plugins/music.js
+++ b/plugins/music.js
@@ -5,10 +5,22 @@ module.exports = function(pluto) {
 
     var musicModule = {
         lastPlaying: null,
+        progress: null,
         queue: [],
         paused: false,
         lastMessage: null
     };
+
+    pluto.addListener("player::progress", function(data) {
+        musicModule.progress = data;
+    });
+    pluto.get("/music/progress", function(req, res) {
+        res.render("music_playing.html", {
+            nowPlaying: musicModule.lastPlaying,
+            progress: musicModule.progress,
+            layout: false
+        });
+    });
 
     pluto.post("/music/add", function(req, response) {
         if (req.body.song) {
@@ -124,7 +136,7 @@ module.exports = function(pluto) {
                     response.redirect("/music");
                     return;
                 }
-                if (!res.body.albums || !res.body.albums.items || res.body.albums.items.length == 0) {
+                if (!res.body.items || res.body.items.length == 0) {
                     musicModule.lastMessage = "Sorry, no results were found.";
                     response.redirect("/music");
                     return;

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -37,15 +37,15 @@ module.exports = function(pluto) {
         //Output format:
         //13.7 (13.7) of 284.0 (04:44.0)
         mplayer.stdout.on('data', function (data) {
-            var match = /\(([\d\.:]+)\) of [\d\.]+ \(([\d\.:]+)\)/.exec(data);
+            var match = /([\d\.:]+) \([\d\.:]+\) of ([\d\.]+) \([\d\.:]+\)/.exec(data);
             if (match) {
                 pluto.emitEvent("player::progress", {
-                    current: match[1],
-                    total: match[2]
+                    current: parseInt(match[1]),
+                    total: parseInt(match[2])
                 });
             }
         });
-    }
+    };
 
     pluto.addListener("music::play", function(song) {
         var songURL = "storage/songs/" + song.id + ".mp3";

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -4,27 +4,55 @@ module.exports = function(pluto) {
     var muzik = require("./muzikdriver.js");
     var request = require('request');
     var progress = require('request-progress');
+    var spawn = require( 'child_process' ).spawn;
     var fs = require('fs');
 
     var player = {};
     var songs = pluto.getStorage("songs");
     var downloading = null;
-    var percent = null;
+    var downloadPercent = null;
+    var mplayer = null;
+    var sentStop = false;
+
+    var playSong = function(songURL, song, url) {
+        mplayer = spawn( 'mplayer', [ '-slave', songURL ] );
+        mplayer.on('exit', function (response) {
+            songProgress = null;
+            mplayer = null;
+            if (response == 0) {
+                console.log("Finished playing");
+                if (sentStop) {
+                    sentStop = false;
+                } else {
+                    pluto.emitEvent("music::next");
+                }
+            } else {
+                console.log("Can't play file, got response: " + response);
+                rm(songURL);
+                if (url) songs[song.id].ignore.push(url);
+                pluto.emitEvent("music::play", song);
+            }
+        });
+
+        //Output format:
+        //13.7 (13.7) of 284.0 (04:44.0)
+        mplayer.stdout.on('data', function (data) {
+            var match = /\(([\d\.:]+)\) of [\d\.]+ \(([\d\.:]+)\)/.exec(data);
+            if (match) {
+                pluto.emitEvent("player::progress", {
+                    current: match[1],
+                    total: match[2]
+                });
+            }
+        });
+    }
 
     pluto.addListener("music::play", function(song) {
         var songURL = "storage/songs/" + song.id + ".mp3";
-        var playCommand = "mkfifo /tmp/mplayer-control;mplayer -slave -input file=/tmp/mplayer-control " + songURL;
+        var playCommand = "mkfifo /tmp/mplayer-control; mplayer -slave -input file=/tmp/mplayer-control " + songURL;
         if (test("-f", songURL)) {
             console.log("Song file exists");
-            exec(playCommand, {async:true},function(code,output){
-                if (code == 0) {
-                    console.log("playing");
-                } else {
-                    console.log("error, deleting file");
-                    rm(songURL);
-                    pluto.emitEvent("music::play", song);
-                }
-            });
+            playSong(songURL, song);
         } else {
             console.log("getting song urls");
             songs[song.id] = songs[song.id] || {ignore: []};
@@ -38,6 +66,7 @@ module.exports = function(pluto) {
                         pluto.emitEvent("music::play", song);
                     } else {
                         downloading = song;
+                        console.log("Starting download");
                         progress(request(url), {
                             throttle: 200
                         })
@@ -47,21 +76,12 @@ module.exports = function(pluto) {
                             pluto.emitEvent("music::play", song);
                         })
                         .on("progress", function(state) {
-                            percent = state.percent;
+                            downloadPercent = state.percent;
                         })
                         .pipe(fs.createWriteStream(songURL)).on('close', function() {
                             console.log("Downloaded file");
                             downloading = null;
-
-                            exec(playCommand, {async:true},function(code,output){
-                                if (code == 0) {
-                                    console.log("playing");
-                                } else {
-                                    songs[song.id].ignore.push(url);
-                                    pluto.saveStorage("songs");
-                                    pluto.emitEvent("music::play", song);
-                                }
-                            });
+                            playSong(songURL, song, url);
                         });
                     }
                 });
@@ -69,31 +89,29 @@ module.exports = function(pluto) {
         }
     });
     pluto.addListener("music::pause",function(song){
-        var pausecommand = "echo \"pause\"> /tmp/mplayer-control";
-        exec(pausecommand, {async:true},function(code,output){
-            console.log("send pause command");
-        })
+        if (!mplayer) return;
+        console.log("Pausing");
+        mplayer.stdin.write("pause\n");
     });
 
     pluto.addListener("music::resume",function(song){
-        var pausecommand = "echo \"pause\"> /tmp/mplayer-control";
-        exec(pausecommand, {async:true},function(code,output){
-            console.log("send resume command");
-        })
+        if (!mplayer) return;
+        console.log("Resuming");
+        mplayer.stdin.write("pause\n");
     });
 
     pluto.addListener("music::stop",function(){
-        var stopcommand = "echo \"stop\" > /tmp/mplayer-control";
-        exec(stopcommand, {async:true}, function(code, output){
-            console.log("stop song");
-        })
+        if (!mplayer) return;
+        console.log("Stopping");
+        sentStop = true;
+        mplayer.stdin.write("stop\n");
     });
 
 
     pluto.get("/music/downloading", function(req, res) {
         res.render("songs_downloading.html", {
             "song": downloading,
-            "percent": percent,
+            "percent": downloadPercent,
             "layout": false
         });
     });

--- a/public/javascripts/helpers.js
+++ b/public/javascripts/helpers.js
@@ -4,9 +4,9 @@ function ajax(method, url, callback) {
     xmlhttp.onreadystatechange = function() {
         if (xmlhttp.readyState == 4 ) {
            if(xmlhttp.status == 200){
-               callback(xmlhttp.responseText);
+               if (callback) callback(xmlhttp.responseText);
            } else if(xmlhttp.status == 400) {
-              console.error('There was an error 400');
+               console.error('There was an error 400');
            } else {
                console.error('something else other than 200 was returned');
            }
@@ -18,11 +18,26 @@ function ajax(method, url, callback) {
 }
 
 function autoUpdate(id, url, interval) {
+    var container = document.getElementById(id);
+    if (!container) return;
+
     var update = function() {
         ajax("GET", url, function(response) {
-            document.getElementById(id).innerHTML = response;
+            container.innerHTML = response;
         });
     }
     setInterval(update, interval*1000);
     update();
+}
+
+function secondsToTime(totalSeconds) {
+    var hours   = Math.floor(totalSeconds / 3600);
+    var minutes = Math.floor((totalSeconds - (hours * 3600)) / 60);
+    var seconds = totalSeconds - (hours * 3600) - (minutes * 60);
+
+    if (hours   < 10) {hours   = "0"+hours;}
+    if (minutes < 10) {minutes = "0"+minutes;}
+    if (seconds < 10) {seconds = "0"+seconds;}
+    var time    = hours+':'+minutes+':'+seconds;
+    return time;
 }

--- a/public/javascripts/music_frontend.js
+++ b/public/javascripts/music_frontend.js
@@ -1,0 +1,39 @@
+autoUpdate("download_progress_container", "/music/downloading", 4);
+
+var currentTime = null;
+var totalTime = null;
+var lastSongResponse = null;
+var songTimer = null;
+var songProgressContainer = document.getElementById("song_progress_container");
+var updateProgressFromServer = function() {
+    ajax("GET", "/music/progress", function(response) {
+        if (response == lastSongResponse) return;
+
+        if (response == "{}") {
+            songProgressContainer.innerHTML = "";
+            clearInterval(songTimer);
+            songTimer = null;
+        } else {
+            progress = JSON.parse(response, songTimer);
+            currentTime = progress.current;
+            totalTime = progress.total;
+            if (!songTimer && progress.playing) {
+                songTimer = setInterval(function() {
+                    currentTime++;
+                    songProgressContainer.innerHTML = "" + secondsToTime(currentTime) + " / " + secondsToTime(totalTime);
+                }, 1000);
+            } else if (songTimer && !progress.playing) {
+                clearInterval(songTimer);
+                songTimer = null;
+            }
+        }
+
+        lastSongResponse = response;
+    });
+}
+
+if (songProgressContainer) {
+    setInterval(updateProgressFromServer, 10000);
+    updateProgressFromServer();
+}
+

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -4,6 +4,7 @@
         <title>Pluto - {{title}}</title>
         <link rel='stylesheet' type='text/css' href='/stylesheets/app.css' />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+        <meta name='viewport' content='width=device-width' />
         <script type="text/javascript" src="/javascripts/helpers.js"></script>
     </head>
     <body>
@@ -18,5 +19,9 @@
         <div class='container'>
             {{{body}}}
         </div>
+
+        {{#each scripts}}
+        <script type="text/javascript" src="{{{.}}}"></script>
+        {{/each}}
     </body>
 </html>

--- a/views/music.html
+++ b/views/music.html
@@ -5,7 +5,9 @@
 {{/if}}
 
 <h2>Music Player</h2>
-<div id="update_container">
+<div id="download_progress_container">
+</div>
+<div id="song_progress_container">
 </div>
 {{#with nowPlaying}}
 <h3>Currently playing</h3>
@@ -107,5 +109,6 @@
 </div>
 
 {{#if nowPlaying}}
-  {{auto_update "update_container" "/music/downloading" 4}}
+  {{auto_update "download_progress_container" "/music/downloading" 4}}
+  {{auto_update "song_progress_container" "/music/progress" 4}}
 {{/if}}

--- a/views/music.html
+++ b/views/music.html
@@ -107,8 +107,3 @@
   <h4>Nothing yet!</h4>
   {{/if}}
 </div>
-
-{{#if nowPlaying}}
-  {{auto_update "download_progress_container" "/music/downloading" 4}}
-  {{auto_update "song_progress_container" "/music/progress" 4}}
-{{/if}}

--- a/views/music_playing.html
+++ b/views/music_playing.html
@@ -1,0 +1,7 @@
+{{#if nowPlaying}}
+{{#with progress}}
+<div class="playing">
+    {{current}} / {{total}}
+</div>
+{{/with}}
+{{/if}}

--- a/views/music_playing.html
+++ b/views/music_playing.html
@@ -1,7 +1,0 @@
-{{#if nowPlaying}}
-{{#with progress}}
-<div class="playing">
-    {{current}} / {{total}}
-</div>
-{{/with}}
-{{/if}}


### PR DESCRIPTION
Instead of using `exec()`, we use `child_process.spawn()` to open a pipe to mplayer. This way we can tell when it finishes to queue up the next song, and show the current progress of the song. The way this is displayed is not very pretty currently but we're going to revamp how the music page is rendered anyway so I'll do that after.

/cc @andrew749 
