### PR TITLE
Make sure Muzik grabs songs correctly and sends error responses

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,6 @@ var pluto = require("./Pluto/pluto.js")({
 	"id": "IP"
 });
 
-// SOURCES
-
 //Keeps track of if users are IN or OUT by.
 //listening for GET requests to /user/io
 pluto.addModule(require("./plugins/users.js")(pluto));
@@ -12,8 +10,6 @@ pluto.addModule(require("./plugins/users.js")(pluto));
 pluto.addModule(require("./plugins/music.js")(pluto));
 
 pluto.addModule(require("./plugins/news_ticker.js")(pluto));
-
-//ACTIONS
 
 //Outputs "Hello, <username>!" in the console
 //when a new user enters
@@ -34,8 +30,11 @@ pluto.addModule(require("./plugins/display.js")(pluto));
 //Play music with Spotify
 //pluto.addModule(require("./plugins/spotify.js")(pluto));
 
-//Play music with Muzik
+//Play music with mplayer
 pluto.addModule(require("./plugins/player.js")(pluto));
+
+//Get music downloads from Muzik
+pluto.addModule(require("./plugins/muzikdriver.js")(pluto));
 
 
 pluto.listen(process.env.PORT || 3000);

--- a/bin/muzik.sh
+++ b/bin/muzik.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-STR="";
-for i in "$@"
-do
-  STR+=$i;
-done;
-STR="http://muzik-api.herokuapp.com/search?songname="+${STR// /_};
-curl $STR;

--- a/plugins/muzikdriver.js
+++ b/plugins/muzikdriver.js
@@ -1,8 +1,54 @@
 module.exports = function(pluto) {
     var Levenshtein = require("levenshtein");
     var muzik = {};
+    muzik.cache = {};
+
+    var getLink = function(urls, song, ignore, callback) {
+        if (!urls) {
+            callback("No urls returned", null);
+            return;
+        }
+
+        // Different forms of the song title we want to look for
+        var targets = [
+            song.name + " " + song.artist,
+            song.artist + " " + song.name,
+            song.name
+        ];
+        var result = _.min(_.filter(urls, function(element) {
+            var url = element[Object.keys(element)[0]];
+            return ignore.indexOf(url) == -1;
+        }), function(element) {
+            return _.reduce(
+
+                // Get distance from each target string
+                targets.map(function(target) {
+                    return new Levenshtein(target, Object.keys(element)[0]).distance;
+                }),
+
+                // Add them up
+                function(memo, num) {
+                    return memo + num;
+                },
+
+                // Demote non-mp3s down
+                (!!element[Object.keys(element)[0]].match(/\.mp3$/) ? 0 : 20)
+            );
+        });
+        if (result == Infinity) {
+            callback("No results", null)
+        } else {
+            var songURL = result[Object.keys(result)[0]];
+            callback(null,songURL);
+        }
+    };
 
     pluto.addListener("muzik::get_link", function (song, ignore, callback) {
+        if (muzik.cache[song.id]) {
+            getLink(muzik.cache[song.id], song, ignore, callback);
+            return;
+        }
+
         var url = 'http://muzik.elasticbeanstalk.com/search?songname=' +
             encodeURIComponent(song.name) + " " +
             encodeURIComponent(song.artist);
@@ -19,43 +65,12 @@ module.exports = function(pluto) {
                 return;
             }
             var urls = body.url;
-            if (!urls) {
-                callback("No urls returned", null);
-                return;
-            }
-
-            // Different forms of the song title we want to look for
-            var targets = [
-                song.name + " " + song.artist,
-                song.artist + " " + song.name,
-                song.name
-            ];
-            var result = _.min(_.filter(urls, function(element) {
-                var url = element[Object.keys(element)[0]];
-                return ignore.indexOf(url) == -1;
-            }), function(element) {
-                return _.reduce(
-
-                    // Get distance from each target string
-                    targets.map(function(target) {
-                        return new Levenshtein(target, Object.keys(element)[0]).distance;
-                    }),
-
-                    // Add them up
-                    function(memo, num) {
-                        return memo + num;
-                    },
-
-                    // Demote non-mp3s down
-                    (!!element[Object.keys(element)[0]].match(/\.mp3$/) ? 0 : 20)
-                );
-            });
-            if (result == Infinity) {
-                callback("No results", null)
-            } else {
-                var songURL = result[Object.keys(result)[0]];
-                callback(null,songURL);
-            }
+            muzik.cache[song.id] = urls;
+            // Keep cache for half an hour so if a link doesn't work, another can be selected
+            setTimeout(function() {
+                delete muzik.cache[song.id];
+            }, 30*60*1000);
+            getLink(urls, song, ignore, callback);
         });
     });
     return muzik;

--- a/plugins/muzikdriver.js
+++ b/plugins/muzikdriver.js
@@ -1,20 +1,62 @@
-var request = require('popsicle');
-var Levenshtein = require("levenshtein");
-module.exports = {
-    getLink: function (song,ignore,callback){
-        request('http://muzik.elasticbeanstalk.com/search?songname='+ song.name + " " + song.artist)
-        .then(function(res){
-            var body = JSON.parse(res.body);
+module.exports = function(pluto) {
+    var Levenshtein = require("levenshtein");
+    var muzik = {};
+
+    pluto.addListener("muzik::get_link", function (song, ignore, callback) {
+        var url = 'http://muzik.elasticbeanstalk.com/search?songname=' +
+            encodeURIComponent(song.name) + " " +
+            encodeURIComponent(song.artist);
+        pluto.request(url, function(res){
+            if (res.status != 200) {
+                callback("Error " + res.status + " connecting to Muzik", null)
+                return;
+            }
+            var body = null;
+            try {
+                body = JSON.parse(res.body);
+            } catch (e) {
+                callback("Error parsing result: " + e, null);
+                return;
+            }
             var urls = body.url;
+            if (!urls) {
+                callback("No urls returned", null);
+                return;
+            }
+
+            // Different forms of the song title we want to look for
+            var targets = [
+                song.name + " " + song.artist,
+                song.artist + " " + song.name,
+                song.name
+            ];
             var result = _.min(_.filter(urls, function(element) {
                 var url = element[Object.keys(element)[0]];
-                return !!url.match(/\.mp3$/) &&
-                    ignore.indexOf(url) == -1;
+                return ignore.indexOf(url) == -1;
             }), function(element) {
-                return new Levenshtein(song.name, Object.keys(element)[0]).distance;
+                return _.reduce(
+
+                    // Get distance from each target string
+                    targets.map(function(target) {
+                        return new Levenshtein(target, Object.keys(element)[0]).distance;
+                    }),
+
+                    // Add them up
+                    function(memo, num) {
+                        return memo + num;
+                    },
+
+                    // Demote non-mp3s down
+                    (!!element[Object.keys(element)[0]].match(/\.mp3$/) ? 0 : 20)
+                );
             });
-            var url = result[Object.keys(result)[0]];
-            callback(Object.keys(result)[0],url);
+            if (result == Infinity) {
+                callback("No results", null)
+            } else {
+                var songURL = result[Object.keys(result)[0]];
+                callback(null,songURL);
+            }
         });
-    }
+    });
+    return muzik;
 }

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -57,6 +57,7 @@ module.exports = function(pluto) {
         var songURL = "storage/songs/" + song.id + ".mp3";
         if (test("-f", songURL)) {
             console.log("Song file exists");
+            downloading = null;
             playSong(songURL, song);
         } else {
             console.log("getting song urls");
@@ -64,6 +65,7 @@ module.exports = function(pluto) {
             pluto.emitEvent("muzik::get_link", song, songs[song.id].ignore, function(err,url) {
                 if (err) {
                     downloadError = err;
+                    pluto.emitEvent("player::download_error", err);
                     attempts = 0;
                     return;
                 }

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -50,6 +50,8 @@ module.exports = function(pluto) {
 
     pluto.addListener("music::play", function(song) {
         downloadError = null;
+        downloadPercent = null;
+        downloading = song;
         var songURL = "storage/songs/" + song.id + ".mp3";
         if (test("-f", songURL)) {
             console.log("Song file exists");
@@ -59,7 +61,7 @@ module.exports = function(pluto) {
             songs[song.id] = songs[song.id] || {ignore: []};
             pluto.emitEvent("muzik::get_link", song, songs[song.id].ignore, function(err,url) {
                 if (err) {
-                    downloadError = e;
+                    downloadError = err;
                     return;
                 }
                 request.head(url, function(err, res, body) {
@@ -71,7 +73,6 @@ module.exports = function(pluto) {
                         pluto.saveStorage("songs");
                         pluto.emitEvent("music::play", song);
                     } else {
-                        downloading = song;
                         console.log("Starting download");
                         progress(request(url), {
                             throttle: 200

--- a/public/javascripts/music_frontend.js
+++ b/public/javascripts/music_frontend.js
@@ -34,6 +34,7 @@ var updateProgressFromServer = function() {
 
 if (songProgressContainer) {
     setInterval(updateProgressFromServer, 10000);
+    setTimeout(updateProgressFromServer, 2000);
     updateProgressFromServer();
 }
 

--- a/test/muzikdriver_test.js
+++ b/test/muzikdriver_test.js
@@ -1,0 +1,188 @@
+var assert = require("assert");
+
+describe("muzikdriver", function(){
+    it("should return the closest title match first", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: JSON.stringify({
+                        albumArt: "",
+                        url: [
+                            {"Arcade Fire - We Used To Wait": "right.mp3"},
+                            {"Arcad Frie - We Wait": "wrong1.mp3"},
+                            {"Eminem - Lose Yourself": "wrong2.mp3"}
+                        ]
+                    })
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, [], function(err, url) {
+            try {
+                assert.equal(err, null);
+                assert.equal(url, "right.mp3");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+    it("should favour mp3 files", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: JSON.stringify({
+                        albumArt: "",
+                        url: [
+                            {"Arcade Fire - We Used To Wait": "right.mp3"},
+                            {"Arcade Fire - We Used To Wait": "wrong"}
+                        ]
+                    })
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, [], function(err, url) {
+            try {
+                assert.equal(err, null);
+                assert.equal(url, "right.mp3");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+    it("should respect ignored urls", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: JSON.stringify({
+                        albumArt: "",
+                        url: [
+                            {"Arcade Fire - We Used To Wait": "ignored.mp3"},
+                            {"We Wait sometimes I guess lol": "right.mp3"}
+                        ]
+                    })
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, ["ignored.mp3"], function(err, url) {
+            try {
+                assert.equal(err, null);
+                assert.equal(url, "right.mp3");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+    it("should return an error when all urls are ignored", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: JSON.stringify({
+                        albumArt: "",
+                        url: [
+                            {"Arcade Fire - We Used To Wait": "ignored1.mp3"},
+                            {"Arcade Fire - We Used To Wait": "ignored2.mp3"},
+                        ]
+                    })
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, ["ignored1.mp3", "ignored2.mp3"], function(err, url) {
+            try {
+                assert.equal(err, "No results", "An error should be returned");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+    it("should return an error when invalid JSON is returned", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: "{url: [}"
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, [], function(err, url) {
+            try {
+                assert.ok(err.match(/Error parsing result/), "An error should be returned");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+    it("should return an error when no data is returned", function(done) {
+        var pluto = require("../Pluto/pluto.js")({
+            testRequests: {
+                "http://muzik.elasticbeanstalk.com/search?songname=We%20Used%20To%20Wait Arcade%20Fire": {
+                    status: 200,
+                    body: '{ "url": [] }'
+                }
+            }
+        });
+        var muzik = require("../plugins/muzikdriver.js")(pluto);
+        pluto.addModule(muzik);
+        pluto.listen();
+        var song = {
+            name: "We Used To Wait",
+            artist: "Arcade Fire",
+            album: "The Suburbs"
+        };
+        pluto.emitEvent("muzik::get_link", song, [], function(err, url) {
+            try {
+                assert.equal(err, "No results", "An error should be returned");
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+});

--- a/views/songs_downloading.html
+++ b/views/songs_downloading.html
@@ -3,9 +3,13 @@
     <p>{{error}}</p>
 </div>
 {{else}}
-{{#if song}}
-<div class="downloading">
-    <p>Downloading {{song.artist}} - {{song.name}} ({{percent}}%)</p>
-</div>
-{{/if}}
+    {{#if song}}
+    <div class="downloading">
+        {{#if percent}}
+        <p>Downloading {{song.artist}} - {{song.name}} ({{percent}}%)</p>
+        {{else}}
+        <p>Fetching links for {{song.artist}} - {{song.name}}</p>
+        {{/if}}
+    </div>
+    {{/if}}
 {{/if}}

--- a/views/songs_downloading.html
+++ b/views/songs_downloading.html
@@ -8,7 +8,7 @@
         {{#if percent}}
         <p>Downloading {{song.artist}} - {{song.name}} ({{percent}}%)</p>
         {{else}}
-        <p>Fetching links for {{song.artist}} - {{song.name}}</p>
+        <p>Fetching links for {{song.artist}} - {{song.name}} (Attempt {{attempts}})</p>
         {{/if}}
     </div>
     {{/if}}

--- a/views/songs_downloading.html
+++ b/views/songs_downloading.html
@@ -1,5 +1,11 @@
+{{#if error}}
+<div class="error">
+    <p>{{error}}</p>
+</div>
+{{else}}
 {{#if song}}
 <div class="downloading">
     <p>Downloading {{song.artist}} - {{song.name}} ({{percent}}%)</p>
 </div>
+{{/if}}
 {{/if}}


### PR DESCRIPTION
This introduces error handling into the Muzik driver so that when there are no good responses, instead of silently dying, we get a message:

![muzikerrors](https://cloud.githubusercontent.com/assets/5315059/9563725/b3f67252-4e5b-11e5-805c-59610a15ea60.gif)

Changes made so that this can happen:
- Muzik is now a normal Pluto module so that requests can be mocked and tested
- Muzik has an array of possible song title formats that are good so that it can better prioritize results
- Instead of directly calling a `getLinks` function, emit a `muzik::get_link` event with the song, ignore list, and callback function
- The Muzik callback function now has the arguments `err, url` instead of `name, url`. We weren't using the song name from here anyway, we only use it internally for sorting results.

TODO:
- [x] Disable play/pause button until the song can actually play
- [x] Show how many links have been tried so you can see some feedback
- [x] Cache hits to Muzik so it doesn't have to do another HTTP request just to try the next song

This addresses https://github.com/pahgawk/Pluto/issues/23.

/cc @andrew749 
