### PR TITLE
Support multiple IDs per user

### DIFF
--- a/Pluto/pluto.js
+++ b/Pluto/pluto.js
@@ -57,6 +57,22 @@ module.exports = function(config, tests) {
                     return new handlebars.SafeString(
                         '<a class="button' + classes + '" href="' + url + '">' + text + '</a>'
                     );
+                } else if (classes.indexOf("in_form") != -1) {
+                    id = makeId(15);
+                    if (classes) {
+                        classes = " " + classes;
+                    }
+                    return new handlebars.SafeString(
+                        '<a class="button' + classes + '" id="' + id + '">' + text + '</a>' +
+                        '<script type="text/javascript">' +
+                            'document.getElementById("' + id + '").addEventListener("click", function() { ' +
+                                'var form = document.createElement("form"); ' +
+                                'form.method = "' + verb + '"; ' +
+                                'form.action = "' + url + '"; ' +
+                                'form.submit(); ' +
+                            ' });' +
+                        '</script>'
+                    );
                 } else {
                     return new handlebars.SafeString(
                         '<form class="button_container" action="' + url + '" method="' + verb + '">' +

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -34,7 +34,7 @@ module.exports = function(pluto) {
     });
 
     pluto.addListener("users::register", function(user) {
-        githubModule.checkGithub(user.id);
+        githubModule.checkGithub(user.username);
     });
 
     return githubModule;

--- a/plugins/users.js
+++ b/plugins/users.js
@@ -2,10 +2,12 @@ module.exports = function(pluto) {
     var path = require("path");
     var fs = require('fs');
 
-    var usersModule = {};
+    var usersModule = {
+        lastMessage: null,
+        listening: null
+    };
 
     var data = pluto.getStorage("users");
-    var listening = 0;
 
     var title = "Manage Users";
 
@@ -17,140 +19,162 @@ module.exports = function(pluto) {
     pluto.get("/users", function(req, res) {
         var users = [];
         for (var user in data) {
+            data[user].addLink = "/users/" + data[user].username + "/add";
             users.push(data[user]);
-            users[users.length-1].encodedid = encodeURIComponent(users[users.length-1].id);
         }
         res.render("users-manage.html", {
-            "users": users,
-            "title": title
+            users: users,
+            title: title,
+            listening: usersModule.listening,
+            message: usersModule.lastMessage
         });
+        usersModule.lastMessage = null;
     });
 
     pluto.post("/users/add", function(req, res) {
-        var users = [];
-        for (var user in data) {
-            users.push(data[user]);
-            users[users.length-1].encodedid = encodeURIComponent(users[users.length-1].id);
+        var username = req.body.username;
+        if (!username) {
+            usersModule.lastMessage = "You need to specify a username!";
+            return res.redirect("/users");
         }
         var name = req.body.name;
-        var github = req.body.github;
-        var artists = req.body.artists || "";
-
-
-        if (!listening) {
-            listening = {
-                "id": 0,
-                "name": name,
-                "github": github,
-                "artists": artists.split(",")
-            };
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": "User " + name + " added. Make the user go to <strong>/users/io</strong> to register an id."
-            });
-        } else {
-            res.status(409);
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": "Can't add a new user yet, we're waiting for " + listening.name + " to register their id!"
-            });
+        if (!name) {
+            usersModule.lastMessage = "You need to specify a name!";
+            return res.redirect("/users");
         }
-    });
-
-    pluto.post("/users/change", function(req, res) {
-        var users = [];
-        for (var user in data) {
-            users.push(data[user]);
-            users[users.length-1].encodedid = encodeURIComponent(users[users.length-1].id);
-        }
-        var id = req.body.id;
-        var newid = req.body.newid;
-        var name = req.body.name;
-        var del = req.body.delete;
         var github = req.body.github;
         var artists = req.body.artists;
         var image = 0;
         if (req.files) image = req.files.image;
 
-        if (data[id]) {
+        if (!usersModule.listening) {
+            usersModule.listening = {
+                username: username,
+                name: name,
+                github: github,
+                ids: [],
+                in: false,
+                artists: artists ? artists.split(/, ?/) : []
+            };
+            if (image) {
+                usersModule.listening.image = image.name;
+            }
+            data[usersModule.listening.username] = usersModule.listening;
+            pluto.saveStorage("users");
+            usersModule.lastMessage = "User " + name + " added.";
+        } else {
+            usersModule.lastMessage = "Can't add a new user yet, we're waiting for " + usersModule.listening.name + " to register their id!";
+        }
+        res.redirect("/users");
+    });
+
+    pluto.post("/users/:username/add", function(req, res) {
+        var user = data[req.params.username];
+        if (!user) {
+            usersModule.lastMessage = "User " + req.params.username + " does not exist.";
+        } else {
+            usersModule.listening = user;
+        }
+        res.redirect("/users");
+    });
+
+    pluto.post("/users/change", function(req, res) {
+        var username = req.body.username;
+        var newusername = req.body.newusername;
+        var name = req.body.name;
+        var del = req.body.delete;
+        var github = req.body.github;
+        var artists = req.body.artists;
+        var ids = req.body.ids;
+        var image = 0;
+        if (req.files) image = req.files.image;
+
+        if (data[username]) {
             if (del) {
-                if (data[id].image && data[id].image.length>0 && fs.existsSync("./public/uploads/" + data[id].image)) fs.unlinkSync("./public/uploads/" + data[id].image);
-                delete data[id];
-                res.send("User deleted.");
+                var deletedName = data[username].name;
+                if (data[username].image && data[username].image.length>0 && fs.existsSync("./public/uploads/" + data[username].image))
+                    fs.unlinkSync("./public/uploads/" + data[username].image);
+                delete data[username];
+                usersModule.lastMessage = "Deleted " + deletedName + "'s user.";
             } else {
-                if (name) data[id].name = name;
-                if (github) data[id].github = github;
-                if (artists) data[id].artists = artists.split(",");
+                data[username].name = name;
+                data[username].github = github;
+                data[username].artists = artists ? artists.split(",") : [];
+                if (!ids || ids == "") {
+                    data[username].ids = [];
+                } else {
+                    data[username].ids = ids.split(/, ?/);
+                }
                 if (image) {
-                    if (data[id].image && data[id].image.length>0 && fs.existsSync("./public/uploads/" + data[id].image)) fs.unlinkSync("./public/uploads/" + data[id].image);
-                    data[id].image = req.files.image.name;
+                    if (data[username].image && data[username].image.length>0 && fs.existsSync("./public/uploads/" + data[username].image))
+                        fs.unlinkSync("./public/uploads/" + data[username].image);
+                    data[username].image = image.name;
                 }
-                if (newid && newid != id) {
-                    data[id].id = newid;
-                    data[newid] = data[id];
-                    delete data[id];
+                if (newusername && newusername != id) {
+                    if (data[newusername]) {
+                        usersModule.lastMessage = "A user already exists with the username " + newusername + ".";
+                        return res.redirect("/users");
+                    } else {
+                        data[username].username = newusername;
+                        data[newusername] = data[username];
+                        delete data[username];
+                    }
                 }
-                res.render("users-manage.html", {
-                    "users": users,
-                    "title": title,
-                    "message": "User changed."
-                });
+                usersModule.lastMessage = "User changed.";
             }
             pluto.saveStorage("users");
         } else {
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": "User does not exist."
-            });
+            usersModule.lastMessage = "User does not exist.";
         }
+        res.redirect("/users");
     });
 
-    pluto.get("/users/io", function(req, res) {
-        var users = [];
-        for (var user in data) {
-            users.push(data[user]);
-            users[users.length-1].encodedid = encodeURIComponent(users[users.length-1].id);
+    pluto.get("/users/:id/io", function(req, res) {
+        var id = req.params.id;
+        if (!id) {
+            usersModule.lastMessage = "No id specified.";
+            return res.redirect("/users");
         }
-        var id = pluto.getId(req, res);
 
-        if (listening) {
-            listening.id = id;
-            listening.in = true;
-            data[id] = listening;
-            listening = 0;
+        if (usersModule.listening) {
+            usersModule.listening.ids.push(id);
+            usersModule.listening.in = true;
 
-            pluto.emitEvent("users::register", data[id]);
+            pluto.emitEvent("users::register", usersModule.listening);
+            usersModule.lastMessage = usersModule.listening.name + " registered!";
 
-            pluto.saveStorage("users");
-
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": data[id].name + " registered!"
-            });
-
-        } else if (data[id]) {
-            data[id].in = (data[id].in?false:true);
-
-            pluto.emitEvent("users::sign" + (data[id].in?"in":"out"), data[id]);
+            usersModule.listening = null;
 
             pluto.saveStorage("users");
 
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": data[id].name + " signed " + (data[id].in?"in":"out") + "!"
-            });
         } else {
-            res.render("users-manage.html", {
-                "users": users,
-                "title": title,
-                "message": "User does not exist: " + id
-            });
+            var currentUser = null;
+            for (var user in data) {
+                if (data[user].ids.indexOf(id) != -1) {
+                    currentUser = data[user];
+                    break;
+                }
+            }
+
+            if (!currentUser) {
+                usersModule.lastMessage = "No user found for that id.";
+                return res.redirect("/users");
+            }
+
+            currentUser.in = !currentUser.in;
+
+            pluto.emitEvent("users::sign" + (currentUser.in?"in":"out"), currentUser);
+
+            pluto.saveStorage("users");
+
+            usersModule.lastMessage = currentUser.name + " signed " + (currentUser.in?"in":"out") + "!";
         }
+        res.redirect("/users");
+    });
+
+    pluto.post("/users/cancel", function(req, res) {
+        usersModule.listening = null;
+        res.redirect("/users");
     });
 
     return usersModule;

--- a/plugins/users.js
+++ b/plugins/users.js
@@ -129,7 +129,7 @@ module.exports = function(pluto) {
         res.redirect("/users");
     });
 
-    pluto.get("/users/:id/io", function(req, res) {
+    pluto.post("/users/:id/io", function(req, res) {
         var id = req.params.id;
         if (!id) {
             usersModule.lastMessage = "No id specified.";

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -20,6 +20,7 @@ $color_primary_highlight: #6AEBD4;
 $color_disabled: #DDF;
 $color_newsitem_highlighted:#BDBDBD;
 $color_link_color: #000;
+$color_message: #ED9;
 
 /* Responsive breakpoints */
 
@@ -34,6 +35,10 @@ body {
     padding:0;
     font-family: 'Roboto', sans-serif;
     background-color: $color_background;
+}
+
+span {
+    vertical-align:middle;
 }
 
 .header {
@@ -147,11 +152,12 @@ form {
     }
 }
 
-input[type="text"], input[type="number"] {
+input[type="text"], input[type="number"], textarea {
     background-color:$color_input;
     border:1px solid $color_input;
     border-radius:4px;
     padding:8px;
+    vertical-align:middle;
     transition: background-color ease 0.3s;
 
     &:hover, &:focus {
@@ -173,6 +179,7 @@ button,
 a.button {
     background-color:$color_main;
     display:inline-block;
+    vertical-align:middle;
     color:$color_main_text;
     padding:15px;
     margin:20px 0 0 0;
@@ -213,6 +220,10 @@ a.button {
             background-color: $color_delete_highlight;
         }
     }
+
+    &.inline {
+        margin: 5px;
+    }
 }
 
 
@@ -221,7 +232,16 @@ form.button_container {
     padding:0;
     margin:0;
     box-shadow:none;
+    vertical-align:middle;
     border-radius:0;
+}
+
+/* Messages */
+.message {
+    background-color: $color_message;
+    padding:10px;
+    border-radius:4px;
+    margin-bottom:20px;
 }
 
 

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -17,13 +17,21 @@ describe("users", function(){
         request(pluto.app)
             .post("/users/add")
             .field("name", "test user")
-            .expect(200)
+            .expect(302)
             .end(function(err, res) {
                 if (err) return done(err);
                 request(pluto.app)
                     .post("/users/add")
-                    .expect(409)
-                    .end(done);
+                    .expect(302)
+                    .end(function(err, res) {
+                        if (err) return done(err);
+                        try {
+                            assert.ok(usersModule.lastMessage, "There should be an error message");
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    });
             });
     });
 
@@ -42,16 +50,20 @@ describe("users", function(){
         request(pluto.app)
             .post("/users/add")
             .field("name", "test user")
-            .expect(200)
+            .expect(302)
             .end(function(err, res) {
                 if (err) return done(err);
                 request(pluto.app)
                     .get("/users/io")
-                    .expect(200)
+                    .expect(302)
                     .end(function(err, res) {
                         if (err) return done(err);
-                        assert.equal(pluto.getStorage("users")["test"].in, true);
-                        done();
+                        try {
+                            assert.equal(pluto.getStorage("users")["test"].in, true);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
                     });
             });
     });
@@ -76,11 +88,15 @@ describe("users", function(){
 
         request(pluto.app)
             .get("/users/io")
-            .expect(200)
+            .expect(302)
             .end(function(err, res) {
                 if (err) return done(err);
-                assert.equal(pluto.getStorage("users")["test"].in, false)
-                done()
+                try {
+                    assert.equal(pluto.getStorage("users")["test"].in, false);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
             });
     });
 
@@ -104,11 +120,15 @@ describe("users", function(){
 
         request(pluto.app)
             .get("/users/io")
-            .expect(200)
+            .expect(302)
             .end(function(err, res) {
                 if (err) return done(err);
-                assert.equal(pluto.getStorage("users")["test"].in, true)
-                done()
+                try {
+                    assert.equal(pluto.getStorage("users")["test"].in, true);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
             });
     });
 });

--- a/views/users-manage.html
+++ b/views/users-manage.html
@@ -4,14 +4,26 @@
 </div>
 {{/if}}
 
+{{#if listening}}
+<div class="message">
+    <span>We are waiting for {{listening.name}} to badge in to register a new id.</span>
+    {{button "POST" "/users/cancel" "Cancel" "small delete inline"}}
+</div>
+{{/if}}
+
 <h2>Existing Users</h2>
 {{#each users}}
 <form method='post' action='/users/change' enctype="multipart/form-data">
-    <input name='id' type='hidden' value='{{id}}' />
+    <input name='username' type='hidden' value='{{username}}' />
     <h3>{{name}}</h3>
     <div class='value'>
-        <label>ID</label>
-        <input name='newid' type='text' value='{{id}}' />
+        <label>Username</label>
+        <input name='newusername' type='text' value='{{username}}' />
+    </div>
+    <div class='value'>
+        <label>IDs</label>
+        <textarea name='ids'>{{ids}}</textarea>
+        {{button "POST" addLink "Register another" "in_form small inline"}}
     </div>
     <div class='value'>
         <label>Name</label>
@@ -35,12 +47,15 @@
         <input type="file" name="image" />
     </div>
     <input type='submit' value='Change' />
-    <a href="/score/{{encodedid}}">View AwesomePoints score</a>
 </form>
 {{/each}}
 
 <h2>Register new user</h2>
-<form method='post' action='/users/add'>
+<form method='post' action='/users/add' enctype="multipart/form-data">
+    <div class='value'>
+        <label>Username</label>
+        <input name='username' type='text' />
+    </div>
     <div class='value'>
         <label>Name</label>
         <input name='name' type='text' />
@@ -51,7 +66,12 @@
     </div>
     <div class='value'>
         <label>Artists</label>
-        <input name='artists' type='text' />
+        <textarea name='artists'></textarea>
+    </div>
+    <div class='value'>
+        <label>Profile Image</label>
+        <div class="icon"></div>
+        <input type="file" name="image" />
     </div>
 
 


### PR DESCRIPTION
This changes the way users are stored. Instead of a user being matched to an IP, a user now has a username created when a user registers. Then, a user can add as many IDs as they want by pressing a button in the web app and then tapping whatever NFC tag they want on the Nexus S (it shouldn't need to write anything to it, so you can use any chip-enabled card too.)

This addresses https://github.com/pahgawk/Pluto/issues/17

/cc @andrew749 
