### PR TITLE
Google Play Music integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ node_modules
 
 # GPM proxy config
 gmusicproxy.cfg
+
+# IDEA
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # UGH WHY
 .DS_Store
+
+# GPM proxy config
+gmusicproxy.cfg

--- a/README.md
+++ b/README.md
@@ -172,13 +172,25 @@ Tests can be run with: `npm test`
 
 
 <h2>Dependencies</h2>
-Text-to-speech requires Festival to work. On linux, run:
+Text-to-speech requires Festival or espeak to work. On linux, run:
 ```
 apt-get install festival
+apt-get install espeak
 ```
 MPlayer to play song links. Run:
 ```
 apt-get install mplayer2
+```
+Google Play Music requires <a href="https://github.com/diraimondo/gmusicproxy">gmusicproxy</a> installed and valid credentials in the config file.
+```
+sudo apt-get install python-pip
+git clone https://github.com/diraimondo/gmusicproxy.git
+cd gmusicproxy
+sudo pip install -r requirements.txt
+
+cd ../Pluto
+mv gmusicproxy-example.cfg gmusicproxy.cfg
+vim gmusicproxy.cfg
 ```
 
 On windows, download and install the binaries from http://downloads.sourceforge.net/e-guidedog/festival-2.1.1-win.7z specifically to the directory `C:\festival` and then add `C:\festival\bin` to your $PATH.

--- a/README.md
+++ b/README.md
@@ -194,3 +194,7 @@ vim gmusicproxy.cfg
 ```
 
 On windows, download and install the binaries from http://downloads.sourceforge.net/e-guidedog/festival-2.1.1-win.7z specifically to the directory `C:\festival` and then add `C:\festival\bin` to your $PATH.
+
+<h2>Troubleshooting</h2>
+
+If GMusicProxy is not initializing properly, run command `GMusicProxy -c gmusicproxy.cfg`. If there is an error `pkg_resources.ContextualVersionConflict`, run `pip freeze` to determine if package versions satisfy the requirements. If not run `pip install <package name> --upgrade`

--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ pluto.addModule("users", require("./plugins/users.js")(pluto));
 //Use Spotify as a source for music info
 pluto.addModule("spotify", require("./plugins/spotify.js")(pluto));
 
+//Use Google Play Music as a source for music info
+pluto.addModule("gpm", require("./plugins/gpm.js")(pluto));
+
 //Makes a playlist based on user recommended artists
 pluto.addModule("music", require("./plugins/music.js")(pluto));
 

--- a/gmusicproxy-example.cfg
+++ b/gmusicproxy-example.cfg
@@ -1,0 +1,3 @@
+email = my.email@gmail.com
+password = my-secret-password
+device-id = 54bbd32a309a34ef

--- a/gmusicproxy-example.cfg
+++ b/gmusicproxy-example.cfg
@@ -1,3 +1,0 @@
-email = my.email@gmail.com
-password = my-secret-password
-device-id = 54bbd32a309a34ef

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "body-parser": "~1.10.1",
+    "cheerio": "^0.19.0",
     "debug": "~2.1.1",
     "es6-promise": "^2.0.1",
     "express": "~4.11.0",
@@ -22,7 +23,7 @@
     "node-sass-middleware": "^0.9.0",
     "path": "^0.11.14",
     "popsicle": "^0.3.10",
-    "request": "^2.61.0",
+    "request": "^2.67.0",
     "request-progress": "^0.3.1",
     "serve-favicon": "~2.2.0",
     "shelljs": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "serve-favicon": "~2.2.0",
     "shelljs": "^0.3.0",
     "should": "^5.0.0",
+    "spotify-data": "0.0.4",
+    "spotify-uri": "^1.0.0",
     "sqlite3": "^3.1.0",
     "supertest": "^1.0.1",
     "underscore": "^1.8.3"

--- a/plugins/gpm.js
+++ b/plugins/gpm.js
@@ -1,0 +1,29 @@
+module.exports = function(pluto) {
+  var spawn = require( 'child_process' ).spawn;
+
+  var gpm = {};
+  
+  gpm.proxy = function() {
+    gpm.proxyProcess = gpm.proxyProcess || spawn('GMusicProxy', ['--config', 'gmusicproxy.cfg']);
+    return gpm.proxyProcess;
+  };
+
+  gpm.killProxy = function() {
+    if (gpm.proxyProcess) {
+      gpm.proxyProcess.stdin.pause();
+      gpm.proxyProcess.kill();
+    }
+  };
+
+  gpm.addURLTo = function(data, song) {
+      data.url = 'http://localhost:9999/get_by_search?type=song' +
+          "&artist=" + encodeURIComponent(song.artist) +
+          "&title=" + encodeURIComponent(song.name);
+      data.streaming = true;
+      return song;
+  };
+
+  gpm.proxy();
+
+  return gpm;
+};

--- a/plugins/music.js
+++ b/plugins/music.js
@@ -48,13 +48,19 @@ module.exports = function(pluto) {
         musicModule.progress = data;
         musicModule.downloading = false;
     });
-    pluto.get("/music/progress", function(req, res) {
+    pluto.get("/music/progress/:id", function(req, res) {
         if (musicModule.lastPlaying && musicModule.progress) {
-            res.json({
-                total: musicModule.progress.total,
-                current: musicModule.progress.current,
-                playing: !musicModule.paused
-            });
+            if (musicModule.lastPlaying.id != req.params.id) {
+                res.send('{"reload": true}');
+            } else {
+                res.json({
+                    total: musicModule.progress.total,
+                    current: musicModule.progress.current,
+                    playing: !musicModule.paused
+                });
+            }
+        } else if (!musicModule.downloading && req.params.id != "none") {
+          res.send('{"reload": true}');
         } else {
             res.json({});
         }
@@ -131,7 +137,7 @@ module.exports = function(pluto) {
                 musicModule.queue.push(nextTrack);
             }
             response.redirect("/music");
-        })
+        });
     });
 
     pluto.addListener("player::download_error", function(err) {
@@ -141,6 +147,7 @@ module.exports = function(pluto) {
 
     pluto.post("/music/play", function(req, res) {
         if (musicModule.downloading) {
+            console.log("Can't play, music is downloading!");
             // Do nothing when waiting for download
         } else if (musicModule.paused) {
             musicModule.paused = false;
@@ -159,6 +166,7 @@ module.exports = function(pluto) {
 
     pluto.post("/music/pause", function(req, res) {
         if (musicModule.downloading) {
+            console.log("Can't pause, music is downloading!");
             // Do nothing when waiting for download
         } else if (musicModule.lastPlaying) {
             musicModule.paused = true;

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -29,7 +29,7 @@ module.exports = function(pluto) {
 
     player.playSong = function(song, url) {
         console.log("got song ", song);
-        mplayer = spawn( 'mplayer', [ '-slave', songs[song.id].url ] );
+        mplayer = spawn( 'mplayer', [ '-slave', songs[song.id].url] );
         mplayer.on('exit', function (response) {
             mplayer = null;
             if (response == 0) {
@@ -54,10 +54,12 @@ module.exports = function(pluto) {
 
         //Output format:
         //13.7 (13.7) of 284.0 (04:44.0)
+        //8.2 (08.2) of -1.3 (unknown)  0.5% 45%
         mplayer.stdout.on('data', function (data) {
             if (sentStop) return;
             data = "" + data;
-            var progressMatch = /([\d\.:]+) \([\d\.:]+\) of ([\d\.]+) \([\d\.:]+\)/.exec(data);
+            console.log(data);
+            var progressMatch = /([\d\.:]+) \([\d\.:]+\) of ([-\d\.]+) \([\w\d\.:]+\)/.exec(data);
             if (progressMatch) {
                 songProgress = {
                     current: parseInt(progressMatch[1]),
@@ -104,11 +106,11 @@ module.exports = function(pluto) {
         downloadError = null;
         downloadPercent = null;
         downloading = song;
-        attempts++;
+        attempts++; 
         songs[song.id] = songs[song.id] || {ignore: []};
         songs[song.id].lastPlayed = Date.now();
         if (songs[song.id].url) {
-            if (test("-f", songs[song.id].url)) {
+            if (song.streaming || test("-f", songs[song.id].url)) {
                 console.log("Song file exists");
                 downloading = null;
                 player.playSong(song, null);
@@ -116,6 +118,9 @@ module.exports = function(pluto) {
                 delete songs[song.id].url;
                 pluto.emitEvent("music::play", song);
             }
+        } else if (pluto.modules.gpm) {
+            songs[song.id] = pluto.modules.gpm.addURLTo(songs[song.id], song);
+            pluto.emitEvent("music::play", song);
         } else {
             console.log("getting song urls");
             pluto.emitEvent("muzik::get_link", song, songs[song.id].ignore, function(err,url) {

--- a/plugins/player.js
+++ b/plugins/player.js
@@ -20,7 +20,7 @@ module.exports = function(pluto) {
 
     player.handleBadSong = function(song, url) {
         console.log("Can't play file");
-        rm(songs[song.id].url);
+        if (!song.streaming) rm(songs[song.id].url);
         delete songs[song.id].url;
         if (url) songs[song.id].ignore.push(url);
         badSong = true;
@@ -58,6 +58,7 @@ module.exports = function(pluto) {
         mplayer.stdout.on('data', function (data) {
             if (sentStop) return;
             data = "" + data;
+            console.log(data);
             var progressMatch = /([\d\.:]+) \([\d\.:]+\) of ([\-\d\.]+) \([\w\d\.:]+\)/.exec(data);
             if (progressMatch) {
                 songProgress = {

--- a/plugins/spotify-data.js
+++ b/plugins/spotify-data.js
@@ -1,0 +1,272 @@
+var url = require('url');
+var util = require('util');
+
+var request = require('request');
+var cheerio = require('cheerio');
+
+/////////////////////////////////
+var Spotify = module.exports = {};
+Spotify.uri = require('spotify-uri');
+/////////////////////////////////
+
+// User agent spoofing
+Spotify.agent = "request";
+
+// Spotify data urls
+Spotify.url = {
+	ws: 'http://ws.spotify.com/lookup/1/.json?uri=%s',
+	playlist: 'https://embed.spotify.com/?uri=spotify:user:%s:playlist:%s',
+	cover: 'https://embed.spotify.com/oembed/?url=%s'
+};
+
+// Available cover sizes
+Spotify.coverSize = {
+	TINY: 60,
+	SMALL: 120,
+	NORMAL: 300,
+	MEDIUM: 300,
+	LARGE: 640,
+	BIG: 640,
+	COVER: 'cover' // size=300 with spotify icon in bottom right
+};
+
+/**
+ * Lookup a spotify uri. Supports track, album, artist, playlist.
+ * @param  {String}   uri Spotify URI to lookup
+ * @param  {Function} cb  Callback
+ */
+Spotify.lookup = function(uri, extras, cb) {
+	var parsed = typeof uri === 'string' ? Spotify.uri.parse(uri) : uri;
+
+	// Playlist
+	if (parsed.type === 'playlist') {
+		Spotify.playlist(parsed.user, parsed.id, typeof extras==='function'?extras:cb);
+	}
+	// Everything else
+	else {
+		var fun = Spotify[parsed.type];
+		if (fun) fun(parsed.id, extras, cb);
+		else cb(new Error('Unknown type'));
+	}
+};
+
+/**
+ * Connects to ws.spotify.com/lookup
+ * @param  {String|Object} uri URI string or object from parsed URI.
+ * @param  {Function} cb
+ * @return {String}        JSON response from spotify
+ */
+Spotify.ws = function(uri, cb) {
+	if (typeof uri !== 'string') uri = Spotify.uri.formatURI(uri);
+
+	request(util.format(Spotify.url.ws, uri), function(err, res, body) {
+		if (err) return cb(err);
+		if (res.statusCode != 200) return cb(res.statusCode);
+
+		cb(null, JSON.parse(body));
+	});
+};
+
+/**
+ * Gets the URL of the album art for any spotify URI.
+ * @param  {String|Object} uri  URI string or object from parsed URI.
+ * @param  {String|Number} size Size of the cover. see the Spotify.coverSize object for available sizes.
+ * @param  {Function} cb
+ * @return {String}        Cover URL
+ */
+Spotify.cover = function(uri, size, cb) {
+	if (typeof size === 'function') {
+		cb = size;
+		size = 'cover';
+	}
+	if (typeof uri !== 'string') uri = Spotify.uri.formatURI(uri);
+
+	request(util.format(Spotify.url.cover, uri), function(err, res, body) {
+		if (err) return cb(err);
+		if (res.statusCode != 200) return cb(res.statusCode);
+
+		var thumbnail_url = JSON.parse(body).thumbnail_url;
+
+		if (!thumbnail_url) return cb(new Error('Thumbnail unavailable'));
+		
+		cb(null, thumbnail_url.replace('cover', size));
+	});
+};
+
+// Add Spotify.<endpoint>, Spotify.<endpoint>.cover and Spotify.<endpoint>.flatten,
+// where endpoint is track, album and artist.
+// eg: Spotify.track(); Spotify.artist.cover(); Spotify.album.flatten();
+['track', 'album', 'artist'].forEach(function(endpoint, i, endpoints) {
+	Spotify[endpoint] = function(uri, extras, cb) {
+		if (typeof extras === 'function') {
+			cb = extras;
+			extras = false;
+		}
+
+		uri = Spotify.uri.formatURI({type: endpoint, id: uri});
+
+		if (extras && i>0) uri = [uri, '&extras=', endpoints[i-1]].join('');
+
+		Spotify.ws(uri, cb);
+	};
+
+	Spotify[endpoint].cover = function(uri, size, cb) {
+		Spotify.cover({type: endpoint, id: uri}, size, cb);
+	};
+
+	Spotify[endpoint].flatten = function(uri, cb) {
+		Spotify.flatten({type: endpoint, id: uri}, cb);
+	};
+});
+
+///////////////////////////////
+// MORE ADVANCED STUFF BELOW //
+///////////////////////////////
+
+/**
+ * Get tracks in a playlist. Same format as an album
+ * @param  {String}   user User/creator of this playlist
+ * @param  {String}   id   ID of the playlist
+ * @param  {Function}      cb
+ * @return {Array}         Array of tracks in playlist
+ */
+Spotify.playlist = function(user, id, cb) {
+	var tracks = [];
+
+	var track = null;
+	
+  var req = request({
+    url: util.format(Spotify.url.playlist, user, id),
+    headers: {
+      "User-Agent": Spotify.agent
+    }
+  }, function(err, res, body) {
+		if (err) return cb(err);
+		if (res.statusCode != 200) return cb(res.statusCode);
+
+		var tracks = [];
+
+		var $ = cheerio.load(body);
+
+		$('li[rel="track"]').each(function(i, el) {
+			el = $(el);
+			var track = {
+				href: Spotify.uri.formatURI({type:'track',id: el.attr('data-track')}),
+				duration: parseInt(el.attr('data-duration-ms')),
+				cover: el.attr('data-ca'),
+				artists: []
+			};
+
+			track.name = el.find('li.track-title').attr('rel').replace(/^\d*\. /, '');
+
+			el.find('li.artist').each(function(i, artistel) {
+				artistel = $(artistel);
+				track.artists.push({
+					href: Spotify.uri.formatURI({type:'artist',id: artistel.attr('class').match(/[\w]{22}/)[0]}),
+					name: artistel.attr('rel')
+				});
+			});
+
+			tracks.push(track);
+		});
+
+		var playlist = {
+			playlist: {
+				// spotify-uri supports parsing of playlist, but not formating -.-
+				'playlist-id': ['spotify', 'user', user, 'playlist', id].join(':'),
+				title: $('div.title-content').text(),
+				tracks: tracks,
+			},
+			info: {
+				type: 'playlist'
+			}
+		};
+
+		cb(null, playlist);
+	});
+};
+
+Spotify.playlist.cover = function(user, id, cb) {
+	// spotify-uri supports parsing of playlist, but not formating -.-
+	var uri = ['spotify', 'user', user, 'playlist', id].join(':');
+	Spotify.cover(uri, cb);
+};
+
+Spotify.playlist.flatten = function(user, id, cb) {
+	// spotify-uri supports parsing of playlist, but not formating -.-
+	var uri = ['spotify', 'user', user, 'playlist', id].join(':');
+	Spotify.flatten(uri, cb);
+};
+
+/**
+ * Flattens an URI to tracks. Ie. an album returns all tracks in the album. an artist returns all tracks by the artist.
+ * @param  {String}   uri Spotify URI to flatten
+ * @param  {Function} cb
+ * @return {Array}        Array of tracks
+ * @todo Arists queries return a lot of duplicate albums (for different territories). Need to extract duplicates somehow.
+ * @todo Make it possible to stream the result. We do many requests which can take a while.
+ */
+Spotify.flatten = function(uri, cb) {
+	if (Array.isArray(uri)) return Spotify.flattenList(uri, cb);
+
+	Spotify.lookup(uri, true, function(err, res) {
+		if (err) return cb(err);
+		if (res.info.type === 'track') {
+			cb(null, [res.track]);
+		} else if (res.info.type === 'album') {
+			// Add album info to every track
+			var album = res.album.tracks.map(function(track, i) {
+				track.album = {
+					href: res.album.href,
+					released: res.album.released,
+					name: res.album.name
+				};
+
+				track['track-number'] = i+1;
+
+				// Expecting that every track in the album has the same availability. Not sure if this is true.
+				track.availability = res.album.availability;
+
+				return track;
+			});
+
+			cb(null, album);
+		} else if (res.info.type === 'playlist') {
+			cb(null, res.playlist.tracks);
+		} else if (res.info.type === 'artist') {
+			var albums = [];
+			res.artist.albums.forEach(function(album) {
+				albums.push(album.album.href);
+			});
+
+			Spotify.flattenList(albums, cb);
+		}
+	});
+};
+
+/**
+ * Same as .flatten, but takes in an array if URIs
+ * @param  {Array}    uris URIs to flatten
+ * @param  {Function} cb
+ * @return {Array}         Array of tracks
+ */
+Spotify.flattenList = function(uris, cb) {
+	var remaining = uris.length;
+
+	// Array of track UIDs
+	var tracks = [];
+	var error = null;
+
+	var done = function() {
+		if (tracks.length === 0) cb(error?error:new Error('No tracks'));
+		cb(null, tracks);
+	};
+
+	uris.forEach(function(uri) {
+		Spotify.flatten(uri, function(err, res) {
+			if (!err) tracks = tracks.concat(res);
+			else error = err;
+			if (--remaining <= 0) done();
+		});
+	});
+};

--- a/plugins/spotify.js
+++ b/plugins/spotify.js
@@ -31,6 +31,25 @@ module.exports = function(pluto) {
         });
     };
 
+    // Obtain song object from song ID
+
+    spotify.getSongFromID = function (id, callback) {
+        pluto.request("https://api.spotify.com/v1/tracks/" + id, function(res) {
+            if (res.status != 200) {
+                return callback("An error occurred: response " + res.status, null);
+            }
+
+            callback(null, {
+                name: res.body.name,
+                album: res.body.album.name,
+                artist: res.body.artists[0].name,
+                id: res.body.id,
+                runtime: Math.round(res.body.duration_ms/1000),
+                art: res.body.album.images && res.body.album.images[1] ? res.body.album.images[1].url : ""
+            });
+        });
+    };
+
     spotify.getAlbum = function(targetAlbum, targetArtist, callback) {
         var searchTerm = (targetArtist ? (encodeURIComponent(targetArtist) + " ") : "") +
             encodeURIComponent(targetAlbum);

--- a/plugins/spotify.js
+++ b/plugins/spotify.js
@@ -13,13 +13,21 @@ module.exports = function(pluto) {
                 return callback("Sorry, no results were found.", null);
             }
             var song = res.body.tracks.items[0];
-            callback(null, {
-                name: song.name,
-                album: song.album.name,
-                artist: song.artists[0].name,
-                id: song.id,
-                art: song.album.images && song.album.images[1] ? song.album.images[1].url : ""
-            });
+
+            pluto.request("https://api.spotify.com/v1/tracks/" + song.id, function(res) {
+                if (res.status != 200) {
+                    return callback("An error occurred: response " + res.status, null);
+                }
+
+                callback(null, {
+                    name: res.body.name,
+                    album: res.body.album.name,
+                    artist: res.body.artists[0].name,
+                    id: res.body.id,
+                    runtime: Math.round(res.body.duration_ms/1000),
+                    art: res.body.album.images && res.body.album.images[1] ? res.body.album.images[1].url : ""
+                });
+            }); 
         });
     };
 
@@ -52,7 +60,8 @@ module.exports = function(pluto) {
                         artist: artist,
                         id: song.id,
                         art: albumArt,
-                    }
+                        runtime: Math.round(song.duration_ms/1000)
+                    };
                 }));
             });
         });
@@ -99,6 +108,7 @@ module.exports = function(pluto) {
                         artist: selectedArtist,
                         id: selectedSong.id,
                         art: albumArt,
+                        runtime: Math.round(selectedSong.duration_ms/1000),
                         choice: selectedUser.name
                     };
                     if (req.params.position == "next") {

--- a/public/javascripts/music_frontend.js
+++ b/public/javascripts/music_frontend.js
@@ -6,7 +6,7 @@ var lastSongResponse = null;
 var songTimer = null;
 var songProgressContainer = document.getElementById("song_progress_container");
 var updateProgressFromServer = function() {
-    ajax("GET", "/music/progress", function(err, response) {
+    ajax("GET", "/music/progress/" + (window.currentID || "none"), function(err, response) {
         if (err) return console.error(err);
         if (response == lastSongResponse) return;
 
@@ -14,6 +14,8 @@ var updateProgressFromServer = function() {
             songProgressContainer.innerHTML = "";
             clearInterval(songTimer);
             songTimer = null;
+        } else if (response == '{"reload": true}') {
+            document.location.reload(true);
         } else {
             progress = JSON.parse(response, songTimer);
             currentTime = progress.current;
@@ -21,7 +23,7 @@ var updateProgressFromServer = function() {
             if (!songTimer && progress.playing) {
                 songTimer = setInterval(function() {
                     currentTime++;
-                    songProgressContainer.innerHTML = "" + secondsToTime(currentTime) + " / " + secondsToTime(totalTime);
+                    songProgressContainer.innerHTML = "" + secondsToTime(currentTime) + " / " + (totalTime == "unknown" ? "unknown" : secondsToTime(totalTime));
                 }, 1000);
             } else if (songTimer && !progress.playing) {
                 clearInterval(songTimer);

--- a/public/javascripts/music_frontend.js
+++ b/public/javascripts/music_frontend.js
@@ -41,3 +41,39 @@ if (songProgressContainer) {
     updateProgressFromServer();
 }
 
+(function makeTabs() {
+
+    tab_lists_anchors = document.querySelectorAll(".adding_tabs li a");
+    divs = document.querySelectorAll("#tabs > div");
+    for (var i = 0; i < tab_lists_anchors.length; i++) {
+        if (tab_lists_anchors[i].classList.contains('active')) {
+            divs[i].style.flex = "1";
+        }
+
+    }
+
+    for (i = 0; i < tab_lists_anchors.length; i++) {
+
+        document.querySelectorAll(".adding_tabs li a")[i].addEventListener('click', function(e) {
+
+            for (i = 0; i < divs.length; i++) {
+                divs[i].style.flex = null;
+            }
+
+            for (i = 0; i < tab_lists_anchors.length; i++) {
+                tab_lists_anchors[i].classList.remove("active");
+            }
+
+            clicked_tab = e.target || e.srcElement;
+
+            clicked_tab.classList.add('active');
+            div_to_show = clicked_tab.getAttribute('href');
+            console.log(document.querySelector(div_to_show));
+            document.querySelector(div_to_show).style.flex = "1";
+
+            e.preventDefault();
+        });
+    }
+
+})();
+

--- a/public/javascripts/music_frontend.js
+++ b/public/javascripts/music_frontend.js
@@ -33,7 +33,7 @@ var updateProgressFromServer = function() {
 
         lastSongResponse = response;
     });
-}
+};
 
 if (songProgressContainer) {
     setInterval(updateProgressFromServer, 10000);

--- a/sass/_music.scss
+++ b/sass/_music.scss
@@ -55,3 +55,59 @@
         font-style:italic;
     }
 }
+
+/* Adding style for tabs to add songs individually or by playlist */
+
+.adding_tabs {
+    overflow: hidden;
+    clear: both;
+    font-size: 0;
+    ul {
+        list-style-type: none;
+        bottom: -1px;
+        position: relative;
+    }
+    li {
+        display: inline-block;
+        margin-bottom: -10px;
+    }
+
+    a {
+        display: block;
+        padding: 5px 10px;
+        color: #000;
+        text-decoration: none;
+        margin: 0 4px;
+        font: 13px/18px verdana, arial, sans-serif;
+        box-shadow: 0 4px 10px $color_container_shadow;
+        border-radius: 4px 4px 0 0;
+        background: #FFFFFF;
+    }
+
+    a.active {
+        margin-bottom: -10px;
+        background: $color_background;
+    }
+
+    #tabs {
+        display: flex;
+        margin: 10px;
+        margin-top: 8px !important;
+        position: relative;
+        z-index: 2;
+        box-shadow: 0 4px 10px $color_container_shadow;
+    }
+    #tabs > div {
+        font-size: 13px;
+        background-color: #fff;
+        overflow: hidden;
+        width: 0;
+        height: 340px;
+        transition: all 0.5s linear;
+        border-top: 4px solid $color_background;
+        border-radius: 4px 4px 0 0;
+    }
+    #tabs form {
+        box-shadow: none !important;
+    }
+}

--- a/views/music.html
+++ b/views/music.html
@@ -10,6 +10,9 @@
 <div id="song_progress_container">
 </div>
 {{#with nowPlaying}}
+<script type="text/javascript">
+  window.currentID = "{{{id}}}";
+</script>
 <h3>Currently playing</h3>
 <div class="song_list">
   <div class="song current">

--- a/views/music.html
+++ b/views/music.html
@@ -44,49 +44,63 @@
   {{button "POST" "/music/shuffle/next" "Play random song next" ""}}
   {{button "POST" "/music/shuffle/end" "Add random song to end" ""}}
 </p>
-<form method="POST" action="/music/add">
-  <div class="value">
-    <label>Artist</label>
-    <input name="artist" type="text" placeholder="Eminem" />
-  </div>
-  <div class="value">
-    <label>Album</label>
-    <input name="album" type="text" placeholder="The Marshall Mathers LP" />
-  </div>
-  <div class="value">
-    <label>Song</label>
-    <input name="song" type="text" placeholder="The Real Slim Shady" />
-  </div>
-  <div class="value">
-    <label>Play next</label>
-    <input type="radio" name="position" value="next" checked />
-  </div>
-  <div class="value">
-    <label>Add to end</label>
-    <input type="radio" name="position" value="end" />
-  </div>
-  <input type="submit" value="Add to Queue" />
-</form>
 
-<form method="POST" action="/music/addPlaylist">
-  <div class="value">
-    <label>User ID</label>
-    <input name="user_id" type="text" placeholder="1234567890" />
+<div class = "adding_tabs">
+  <ul>
+    <li><a href="#tab1" class="active">Add a song</a></li>
+    <li><a href="#tab2">Add a playlist</a></li>
+  </ul>
+  <div id="tabs">
+    <div id="tab1">
+      <form method="POST" action="/music/add">
+        <div class="value">
+          <label>Artist</label>
+          <input name="artist" type="text" placeholder="Eminem" />
+        </div>
+        <div class="value">
+          <label>Album</label>
+          <input name="album" type="text" placeholder="The Marshall Mathers LP" />
+        </div>
+        <div class="value">
+          <label>Song</label>
+          <input name="song" type="text" placeholder="The Real Slim Shady" />
+        </div>
+        <div class="value">
+          <label>Play next</label>
+          <input type="radio" name="position" value="next" checked />
+        </div>
+        <div class="value">
+          <label>Add to end</label>
+          <input type="radio" name="position" value="end" />
+        </div>
+        <input type="submit" value="Add to Queue" />
+      </form>
+    </div>
+
+    <div id="tab2">
+      <form method="POST" action="/music/addPlaylist">
+        <div class="value">
+          <label>User ID</label>
+          <input name="user_id" type="text" placeholder="1234567890" />
+        </div>
+        <div class="value">
+          <label>Playlist ID</label>
+          <input name="playlist_id" type="text" placeholder="1234567890" />
+        </div>
+        <div class="value">
+          <label>Play next</label>
+          <input type="radio" name="position" value="next" checked />
+        </div>
+        <div class="value">
+          <label>Add to end</label>
+          <input type="radio" name="position" value="end" />
+        </div>
+        <input type="submit" value="Add to Queue" />
+      </form>
+    </div>
   </div>
-  <div class="value">
-    <label>Playlist ID</label>
-    <input name="playlist_id" type="text" placeholder="1234567890" />
-  </div>
-  <div class="value">
-    <label>Play next</label>
-    <input type="radio" name="position" value="next" checked />
-  </div>
-  <div class="value">
-    <label>Add to end</label>
-    <input type="radio" name="position" value="end" />
-  </div>
-  <input type="submit" value="Add to Queue" />
-</form>
+
+</div>
 
 <h3>Queue</h3>
 <div class="song_list">

--- a/views/music.html
+++ b/views/music.html
@@ -68,6 +68,26 @@
   <input type="submit" value="Add to Queue" />
 </form>
 
+<form method="POST" action="/music/addPlaylist">
+  <div class="value">
+    <label>User ID</label>
+    <input name="user_id" type="text" placeholder="1234567890" />
+  </div>
+  <div class="value">
+    <label>Playlist ID</label>
+    <input name="playlist_id" type="text" placeholder="1234567890" />
+  </div>
+  <div class="value">
+    <label>Play next</label>
+    <input type="radio" name="position" value="next" checked />
+  </div>
+  <div class="value">
+    <label>Add to end</label>
+    <input type="radio" name="position" value="end" />
+  </div>
+  <input type="submit" value="Add to Queue" />
+</form>
+
 <h3>Queue</h3>
 <div class="song_list">
   {{#if queue}}


### PR DESCRIPTION
This runs the Google Play Music proxy in the background so that going to a url searching for a track by name and artist returns a streamable mp3 that is playable by mplayer in our existing system. Updates to make this work include:
- Adding a "streaming" flag so Pluto doesn't check that a file has been downloaded
- Save the runtime for a song in the data structure since mplayer doesn't get the total length of songs from streaming mp3s

Additionally:
- The URL that is polled to get song progress now includes the spotify ID of the current song so that if the ID has changed (a new song is playing), the client can know to reload the page to see the new content
- A playback bug is fixed where manually skipping to the next song stops playing/pausing from working due to the reference to mplayer being overwritten asynchronously

@Kong-Artist @andrew749 
